### PR TITLE
Add await to Prisma queries

### DIFF
--- a/src/modules/books/books.service.ts
+++ b/src/modules/books/books.service.ts
@@ -1,11 +1,11 @@
 import { prisma, getRandomNumber } from "../../utils"
 
 export async function getBooks() {
-  return prisma.book.findMany()
+  return await prisma.book.findMany()
 }
 
 export async function getBook(id: number) {
-  return prisma.book.findUnique({
+  return await prisma.book.findUnique({
     where: { id }
   })
 }
@@ -14,7 +14,7 @@ export async function getRandomBook() {
   const resultLength = await prisma.book.count()
   const id = getRandomNumber(0, resultLength)
 
-  return prisma.book.findUnique({
+  return await prisma.book.findUnique({
     where: { id }
   })
 }

--- a/src/modules/catFacts/catFacts.service.ts
+++ b/src/modules/catFacts/catFacts.service.ts
@@ -1,11 +1,11 @@
 import { prisma, getRandomNumber } from "../../utils"
 
 export async function getCatFacts() {
-  return prisma.catFact.findMany()
+  return await prisma.catFact.findMany()
 }
 
 export async function getCatFact(id: number) {
-  return prisma.catFact.findUnique({
+  return await prisma.catFact.findUnique({
     where: { id }
   })
 }
@@ -14,7 +14,7 @@ export async function getRandomCatFact() {
   const resultLength = await prisma.catFact.count()
   const id = getRandomNumber(0, resultLength)
 
-  return prisma.catFact.findUnique({
+  return await prisma.catFact.findUnique({
     where: { id }
   })
 }

--- a/src/modules/jokes/jokes.service.ts
+++ b/src/modules/jokes/jokes.service.ts
@@ -1,11 +1,11 @@
 import { prisma, getRandomNumber } from "../../utils"
 
 export async function getJokes() {
-  return prisma.joke.findMany()
+  return await prisma.joke.findMany()
 }
 
 export async function getJoke(id: number) {
-  return prisma.joke.findUnique({
+  return await prisma.joke.findUnique({
     where: { id }
   })
 }
@@ -14,7 +14,7 @@ export async function getRandomJoke() {
   const resultLength = await prisma.joke.count()
   const id = getRandomNumber(0, resultLength)
 
-  return prisma.joke.findUnique({
+  return await prisma.joke.findUnique({
     where: { id }
   })
 }

--- a/src/modules/nbaTeams/nbaTeams.service.ts
+++ b/src/modules/nbaTeams/nbaTeams.service.ts
@@ -1,11 +1,11 @@
 import { prisma, getRandomNumber } from "../../utils"
 
 export async function getNbaTeams() {
-  return prisma.nbaTeam.findMany()
+  return await prisma.nbaTeam.findMany()
 }
 
 export async function getNbaTeam(id: number) {
-  return prisma.nbaTeam.findUnique({
+  return await prisma.nbaTeam.findUnique({
     where: { id }
   })
 }
@@ -14,7 +14,7 @@ export async function getRandomNbaTeam() {
   const resultLength = await prisma.nbaTeam.count()
   const id = getRandomNumber(0, resultLength)
 
-  return prisma.nbaTeam.findUnique({
+  return await prisma.nbaTeam.findUnique({
     where: { id }
   })
 }

--- a/src/modules/oldGames/oldGames.service.ts
+++ b/src/modules/oldGames/oldGames.service.ts
@@ -1,11 +1,11 @@
 import { prisma, getRandomNumber } from "../../utils"
 
 export async function getOldGames() {
-  return prisma.oldGame.findMany()
+  return await prisma.oldGame.findMany()
 }
 
 export async function getOldGame(id: number) {
-  return prisma.oldGame.findUnique({
+  return await prisma.oldGame.findUnique({
     where: { id }
   })
 }
@@ -14,7 +14,7 @@ export async function getRandomOldGame() {
   const resultLength = await prisma.oldGame.count()
   const id = getRandomNumber(0, resultLength)
 
-  return prisma.oldGame.findUnique({
+  return await prisma.oldGame.findUnique({
     where: { id }
   })
 }

--- a/src/modules/quotes/quotes.service.ts
+++ b/src/modules/quotes/quotes.service.ts
@@ -1,11 +1,11 @@
 import { prisma, getRandomNumber } from "../../utils"
 
 export async function getQuotes() {
-  return prisma.quote.findMany()
+  return await prisma.quote.findMany()
 }
 
 export async function getQuote(id: number) {
-  return prisma.quote.findUnique({
+  return await prisma.quote.findUnique({
     where: { id }
   })
 }
@@ -14,7 +14,7 @@ export async function getRandomQuote() {
   const resultLength = await prisma.quote.count()
   const id = getRandomNumber(0, resultLength)
 
-  return prisma.quote.findUnique({
+  return await prisma.quote.findUnique({
     where: { id }
   })
 }

--- a/src/modules/social/auth/auth.service.ts
+++ b/src/modules/social/auth/auth.service.ts
@@ -14,7 +14,7 @@ export async function createProfile(input: CreateProfileInput) {
 }
 
 export async function findProfileByEmail(email: string) {
-  return prisma.profile.findUnique({
+  return await prisma.profile.findUnique({
     where: {
       email
     }

--- a/src/modules/social/posts/posts.service.ts
+++ b/src/modules/social/posts/posts.service.ts
@@ -8,7 +8,7 @@ import {
 } from "./posts.schema"
 
 export async function getPosts(sort: keyof Post = "created", sortOrder: "asc" | "desc" = "desc", limit = 100, offset = 0, includes: PostIncludes = {}) {
-  return prisma.post.findMany({
+  return await prisma.post.findMany({
     orderBy: {
       [sort]: sortOrder
     },
@@ -27,7 +27,7 @@ export async function getPosts(sort: keyof Post = "created", sortOrder: "asc" | 
 }
 
 export async function getPost(id: number, includes: PostIncludes = {}) {
-  return prisma.post.findUnique({
+  return await prisma.post.findUnique({
     where: { id },
     include: {
       ...includes,
@@ -41,8 +41,8 @@ export async function getPost(id: number, includes: PostIncludes = {}) {
   })
 }
 
-export const createPost = (data: CreatePostSchema, includes: PostIncludes = {}) => {
-  return prisma.post.create({
+export const createPost = async (data: CreatePostSchema, includes: PostIncludes = {}) => {
+  return await prisma.post.create({
     data: {
       ...data,
       created: new Date(),
@@ -60,8 +60,8 @@ export const createPost = (data: CreatePostSchema, includes: PostIncludes = {}) 
   })
 }
 
-export const updatePost = (id: number, data: CreatePostBaseSchema, includes: PostIncludes = {}) =>
-  prisma.post.update({
+export const updatePost = async (id: number, data: CreatePostBaseSchema, includes: PostIncludes = {}) =>
+  await prisma.post.update({
     data: {
       ...data,
       updated: new Date()
@@ -80,8 +80,8 @@ export const updatePost = (id: number, data: CreatePostBaseSchema, includes: Pos
     }
   })
 
-export const deletePost = (id: number) =>
-  prisma.post.delete({
+export const deletePost = async (id: number) =>
+  await prisma.post.delete({
     where: {
       id
     }
@@ -122,7 +122,7 @@ export const createComment = async (
   postId: number,
   owner: string,
   comment: CreateCommentSchema
-) => prisma.comment.create({
+) => await prisma.comment.create({
   data: {
     body: comment.body,
     replyToId: comment.replyToId,
@@ -139,15 +139,15 @@ export const createComment = async (
   }
 })
 
-export const deleteComment = (id: number) =>
-  prisma.comment.delete({
+export const deleteComment = async (id: number) =>
+  await prisma.comment.delete({
     where: {
       id
     }
   })
 
-export const getComment = (id: number) =>
-  prisma.comment.findUnique({
+export const getComment = async (id: number) =>
+  await prisma.comment.findUnique({
     where: {
       id
     },

--- a/src/modules/social/profiles/profiles.service.ts
+++ b/src/modules/social/profiles/profiles.service.ts
@@ -4,7 +4,7 @@ import { ProfileIncludes } from "./profiles.controller"
 import { ProfileMediaSchema } from "./profiles.schema"
 
 export async function getProfiles(sort: keyof Profile = "name", sortOrder: "asc" | "desc" = "desc", limit = 100, offset = 0, includes: ProfileIncludes = {}) {
-  return prisma.profile.findMany({
+  return await prisma.profile.findMany({
     include: {
       ...includes,
       _count: {
@@ -23,7 +23,7 @@ export async function getProfiles(sort: keyof Profile = "name", sortOrder: "asc"
   })
 }
 
-export const getProfile = (name: string, includes: ProfileIncludes = {}) => prisma.profile.findUnique({
+export const getProfile = async (name: string, includes: ProfileIncludes = {}) => await prisma.profile.findUnique({
   where: { name },
   include: {
     ...includes,
@@ -37,24 +37,22 @@ export const getProfile = (name: string, includes: ProfileIncludes = {}) => pris
   }
 })
 
-export const createProfile = (data: Prisma.ProfileCreateInput) => {
-  return prisma.profile.create({ data })
+export const createProfile = async (data: Prisma.ProfileCreateInput) => {
+  return await prisma.profile.create({ data })
 }
 
 export const updateProfileMedia = async (name: string, { avatar, banner }: ProfileMediaSchema) => {
-  prisma.profile.update({
+  return await prisma.profile.update({
+    where: { name },
     data: {
       avatar,
       banner
     },
-    where: {
-      name
-    }
   })
 }
 
 export const followProfile = async (target: string, follower: string) => {
-  return prisma.profile.update({
+  return await prisma.profile.update({
     where: {
       name: follower
     },
@@ -85,7 +83,7 @@ export const followProfile = async (target: string, follower: string) => {
 }
 
 export const unfollowProfile = async (target: string, follower: string) => {
-  return prisma.profile.update({
+  return await prisma.profile.update({
     where: {
       name: follower
     },
@@ -113,4 +111,4 @@ export const unfollowProfile = async (target: string, follower: string) => {
       }
     }
   })
-} 
+}


### PR DESCRIPTION
- Adds `await` keyword to all queries that interact with Prisma.

According to [this discussion](https://github.com/prisma/prisma/discussions/3781), it's required as the Prisma client is lazy, and only evaluates when `await` is called.