### PR TITLE
Fix error validations

### DIFF
--- a/src/modules/social/posts/posts.schema.ts
+++ b/src/modules/social/posts/posts.schema.ts
@@ -22,7 +22,8 @@ export const postCore = {
       invalid_type_error: "Body must be a string"
     })
     .max(280, "Body cannot be greater than 280 characters")
-    .trim(),
+    .trim()
+    .nullish(),
   ...tagsAndMedia
 }
 
@@ -124,7 +125,10 @@ export const createPostBaseSchema = z.object(postCore)
 
 export const updatePostBodySchema = z
   .object(updatePostCore)
-  .refine(({ title, body }) => !!title || !!body, "You must provide either title or body")
+  .refine(
+    ({ title, body, tags, media }) => !!title || !!body || !!tags || !!media,
+    "You must provide either title, body, tags, or media"
+  )
 
 export const createPostSchema = z.object({
   ...postOwner,
@@ -141,8 +145,8 @@ export const displayPostSchema = z.object({
     .object({
       name: z.string(),
       email: z.string().email(),
-      avatar: z.string().url().nullable(),
-      banner: z.string().url().nullable()
+      avatar: z.string().nullable(),
+      banner: z.string().nullable()
     })
     .optional(),
   _count: z

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,7 +27,10 @@ import socialAuthRoutes from "./modules/social/auth/auth.route"
 
 // Main startup
 function buildServer() {
-  const server = Fastify().withTypeProvider<ZodTypeProvider>()
+  const server = Fastify({
+    // Allows routes to end with a slash instead of throwing a 404
+    ignoreTrailingSlash: true
+  }).withTypeProvider<ZodTypeProvider>()
 
   // Set custom validator and serializer compilers for Zod
   server.setValidatorCompiler(validatorCompiler)


### PR DESCRIPTION
- Removes `.url()` from post `_author` flag response schema.
- Makes sure at least one of title, body, tags or media is provided when updating a post.
- Makes `body` property optional when creating a post.
- Adds `ignoreTrailingSlash: true` to Fastify config. This will make sure both `/api/v1/books` and `/api/v1/books/` work, instead of throwing a 404 in some cases if you include the trailing slash.