### PR TITLE
Get all posts by user

### DIFF
--- a/src/modules/social/posts/posts.service.ts
+++ b/src/modules/social/posts/posts.service.ts
@@ -136,6 +136,7 @@ export const createComment = async (
     created: true,
     owner: true,
     replyToId: true,
+    postId: true
   }
 })
 

--- a/src/modules/social/profiles/profiles.route.ts
+++ b/src/modules/social/profiles/profiles.route.ts
@@ -12,8 +12,10 @@ import {
   getProfileHandler,
   updateProfileMediaHandler,
   followProfileHandler,
-  unfollowProfileHandler
+  unfollowProfileHandler,
+  getProfilePostsHandler
 } from "./profiles.controller"
+import { displayPostSchema, postsQuerySchema } from "../posts/posts.schema"
 
 async function profilesRoutes(server: FastifyInstance) {
   server.get(
@@ -90,6 +92,23 @@ async function profilesRoutes(server: FastifyInstance) {
       }
     },
     unfollowProfileHandler
+  )
+
+  server.get(
+    "/:name/posts",
+    {
+      preHandler: [server.authenticate],
+      schema: {
+        tags: ["profiles"],
+        security: [{ bearerAuth: [] }],
+        params: profileNameSchema,
+        querystring: postsQuerySchema,
+        response: {
+          200: displayPostSchema.array()
+        }
+      }
+    },
+    getProfilePostsHandler
   )
 }
 

--- a/src/modules/social/profiles/profiles.service.ts
+++ b/src/modules/social/profiles/profiles.service.ts
@@ -1,7 +1,8 @@
-import { Prisma, Profile } from "@prisma/client"
+import { Prisma, Profile, Post } from "@prisma/client"
 import { prisma } from "../../../utils"
 import { ProfileIncludes } from "./profiles.controller"
 import { ProfileMediaSchema } from "./profiles.schema"
+import { PostIncludes } from "../posts/posts.controller"
 
 export async function getProfiles(sort: keyof Profile = "name", sortOrder: "asc" | "desc" = "desc", limit = 100, offset = 0, includes: ProfileIncludes = {}) {
   return await prisma.profile.findMany({
@@ -107,6 +108,26 @@ export const unfollowProfile = async (target: string, follower: string) => {
         select: {
           name: true,
           avatar: true,
+        }
+      }
+    }
+  })
+}
+
+export const getProfilePosts = async (name: string, sort: keyof Post = "created", sortOrder: "asc" | "desc" = "desc", limit = 100, offset = 0, includes: PostIncludes = {}) => {
+  return await prisma.post.findMany({
+    where: { owner: name },
+    orderBy: {
+      [sort]: sortOrder
+    },
+    take: limit,
+    skip: offset,
+    include: {
+      ...includes,
+      _count: {
+        select: {
+          comments: true,
+          reactions: true,
         }
       }
     }


### PR DESCRIPTION
- Adds a new `GET /social/profiles/:name/posts` endpoint to retrieve all posts by username.
- Return `postId` field after creating comment. This is in line with reacting and is also what docs specify.

[Related docs PR](https://github.com/NoroffFEU/noroff-api-docs/pull/9/files)