### PR TITLE
Init new db & misc

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,8 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
-    "dev": "tsnd --respawn --transpile-only src/app.ts",
+    "dev": "tsnd --respawn --transpile-only --exit-child src/app.ts",
     "start": "node dist/src/app.js",
-    "prestart": "npm run build",
     "build": "rimraf dist && tsc -p tsconfig.json && npm run copy-images",
     "prebuild": "prisma generate",
     "copy-images": "copyfiles -u 1 \"src/public/**/*\" dist/src"

--- a/prisma/migrations/20221027084127_init_new_db/migration.sql
+++ b/prisma/migrations/20221027084127_init_new_db/migration.sql
@@ -1,0 +1,23 @@
+-- DropForeignKey
+ALTER TABLE "Comment" DROP CONSTRAINT "Comment_owner_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Comment" DROP CONSTRAINT "Comment_postId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Post" DROP CONSTRAINT "Post_owner_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Reaction" DROP CONSTRAINT "Reaction_postId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "Post" ADD CONSTRAINT "Post_owner_fkey" FOREIGN KEY ("owner") REFERENCES "Profile"("name") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Reaction" ADD CONSTRAINT "Reaction_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Comment" ADD CONSTRAINT "Comment_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Comment" ADD CONSTRAINT "Comment_owner_fkey" FOREIGN KEY ("owner") REFERENCES "Profile"("name") ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
- Adds new Prisma migration file for new db. Realistically this just fixes cascade foreign keys with Prisma v4 upgrade.
- Removes `prestart` script.
  - Initially this was just a shorthand to not require building manually. Render runs both the build and start scripts separately, which results in 2 builds and a extra long startup time. Removing this script should reduce PR merge->live time by ~50%.
- Adds `--exit-child` flag to `tsnd` for `dev` script. This will fix the need for restarting dev script manually when making changes locally, and instead will restart it automatically on save.