### PR TITLE
Upgrade node types

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/http-errors": "^1.8.2",
-    "@types/node": "^18.7.15",
+    "@types/node": "^18.11.9",
     "@types/node-schedule": "^2.1.0",
     "@types/statuses": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^5.36.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -238,15 +238,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*":
+"@types/node@*", "@types/node@^18.11.9":
   version "18.11.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
   integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
-
-"@types/node@^18.7.15":
-  version "18.7.23"
-  resolved "https://registry.npmjs.org/@types/node/-/node-18.7.23.tgz"
-  integrity sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==
 
 "@types/statuses@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
- Upgrades node types to 18.11.9 to resolve conflicting definitions with node-schedule package.