### PR TITLE
Add Auction tags + filter for tag

### DIFF
--- a/prisma/migrations/20221115120500_auction/migration.sql
+++ b/prisma/migrations/20221115120500_auction/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "AuctionListing" ADD COLUMN     "tags" TEXT[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -128,6 +128,7 @@ model AuctionListing {
   title       String
   description String?
   media       String[]
+  tags        String[]
   created     DateTime       @default(now())
   updated     DateTime       @default(now())
   endsAt      DateTime

--- a/src/modules/auction/listings/listings.controller.ts
+++ b/src/modules/auction/listings/listings.controller.ts
@@ -30,12 +30,12 @@ export async function getListingsHandler(
       sortOrder?: "asc" | "desc"
       _seller?: boolean
       _bids?: boolean
-      _tags?: string
+      _tag?: string
     }
   }>,
   reply: FastifyReply
 ) {
-  const { sort, sortOrder, limit, offset, _bids, _seller, _tags } = request.query
+  const { sort, sortOrder, limit, offset, _bids, _seller, _tag } = request.query
 
   if (limit && limit > 100) {
     throw new BadRequest("Limit cannot be greater than 100")
@@ -46,7 +46,7 @@ export async function getListingsHandler(
     seller: Boolean(_seller)
   }
 
-  const listings = await getListings(sort, sortOrder, limit, offset, includes, _tags)
+  const listings = await getListings(sort, sortOrder, limit, offset, includes, _tag)
   reply.code(200).send(listings)
 }
 

--- a/src/modules/auction/listings/listings.controller.ts
+++ b/src/modules/auction/listings/listings.controller.ts
@@ -30,11 +30,12 @@ export async function getListingsHandler(
       sortOrder?: "asc" | "desc"
       _seller?: boolean
       _bids?: boolean
+      _tags?: string
     }
   }>,
   reply: FastifyReply
 ) {
-  const { sort, sortOrder, limit, offset, _bids, _seller } = request.query
+  const { sort, sortOrder, limit, offset, _bids, _seller, _tags } = request.query
 
   if (limit && limit > 100) {
     throw new BadRequest("Limit cannot be greater than 100")
@@ -45,7 +46,7 @@ export async function getListingsHandler(
     seller: Boolean(_seller)
   }
 
-  const listings = await getListings(sort, sortOrder, limit, offset, includes)
+  const listings = await getListings(sort, sortOrder, limit, offset, includes, _tags)
   reply.code(200).send(listings)
 }
 

--- a/src/modules/auction/listings/listings.schema.ts
+++ b/src/modules/auction/listings/listings.schema.ts
@@ -148,7 +148,7 @@ export const listingQuerySchema = z.object({
         .int()
     )
     .optional(),
-  _tags: z
+  _tag: z
     .string({
       invalid_type_error: "Tag must be a string"
     })

--- a/src/modules/auction/listings/listings.service.ts
+++ b/src/modules/auction/listings/listings.service.ts
@@ -9,8 +9,15 @@ export async function getListings(
   sortOrder: "asc" | "desc" = "desc",
   limit = 100,
   offset = 0,
-  includes: AuctionListingIncludes = {}
+  includes: AuctionListingIncludes = {},
+  tag: string | undefined
 ) {
+  const whereTag = tag
+    ? {
+        tags: { has: tag }
+      }
+    : {}
+
   return await prisma.auctionListing.findMany({
     include: {
       ...includes,
@@ -20,6 +27,7 @@ export async function getListings(
         }
       }
     },
+    where: { ...whereTag },
     orderBy: {
       [sort]: sortOrder
     },
@@ -48,6 +56,7 @@ export async function createListing(data: CreateListingSchema, seller: string, i
       ...data,
       sellerName: seller,
       media: data.media || [],
+      tags: data.tags || [],
       created: new Date(),
       updated: new Date()
     },
@@ -72,6 +81,7 @@ export async function updateListing(id: string, data: UpdateListingSchema, inclu
       ...data,
       title: data.title || undefined,
       media: data.media || undefined,
+      tags: data.tags || undefined,
       updated: new Date()
     },
     include: {


### PR DESCRIPTION
- Adds `tags` array to Auction listings.
- Adds `?_tag=x` flag to `GET /auction/listings` with ability to filter by tag.

Each listing can have multiple tags, but the `?_tag=` filter flag only accept filtering by a single tag.
For example: `GET /auction/listings?_tag=chuck_norris` will return all listings that includes a `chuck_norris` tag in its tags array.

Closes #34 