### PR TITLE
Add _tag flag to Social posts

### DIFF
--- a/src/modules/social/posts/posts.controller.ts
+++ b/src/modules/social/posts/posts.controller.ts
@@ -24,11 +24,12 @@ export async function getPostsHandler(
       _comments?: boolean,
       sort?: keyof Post
       sortOrder?: "asc" | "desc"
+      _tag?: string
     }
   }>,
   reply: FastifyReply
 ) {
-  const { sort, sortOrder, limit, offset, _author, _reactions, _comments } = request.query
+  const { sort, sortOrder, limit, offset, _author, _reactions, _comments, _tag } = request.query
 
   if (limit && limit > 100) {
     throw new BadRequest("Limit cannot be greater than 100")
@@ -40,7 +41,7 @@ export async function getPostsHandler(
     comments: Boolean(_comments)
   }
 
-  const posts = await getPosts(sort, sortOrder, limit, offset, includes)
+  const posts = await getPosts(sort, sortOrder, limit, offset, includes, _tag)
   reply.code(200).send(posts)
 }
 
@@ -277,12 +278,13 @@ export async function getPostsOfFollowedUsersHandler(
       _author?: boolean
       _reactions?: boolean
       _comments?: boolean
+      _tag?: string
     }
   }>,
   reply: FastifyReply
 ) {
   const { id } = request.user as Profile
-  const { sort, sortOrder, limit, offset, _author, _reactions, _comments } = request.query
+  const { sort, sortOrder, limit, offset, _author, _reactions, _comments, _tag } = request.query
 
   if (limit && limit > 100) {
     throw new BadRequest("Limit cannot be greater than 100")
@@ -295,7 +297,7 @@ export async function getPostsOfFollowedUsersHandler(
   }
 
   try {
-    const posts = await getPostsOfFollowedUsers(id, sort, sortOrder, limit, offset, includes)
+    const posts = await getPostsOfFollowedUsers(id, sort, sortOrder, limit, offset, includes, _tag)
     reply.code(200).send(posts)
   } catch (error) {
     reply.code(500).send(error)

--- a/src/modules/social/posts/posts.schema.ts
+++ b/src/modules/social/posts/posts.schema.ts
@@ -185,6 +185,9 @@ export const postsQuerySchema = z
     offset: z.preprocess(val => parseInt(val as string, 10), z.number({
       invalid_type_error: "Offset must be a number"
     }).int()).optional(),
+    _tag: z.string({
+      invalid_type_error: "Tag must be a string"
+    }).optional(),
     ...queryFlagsCore
   })
 

--- a/src/modules/social/posts/posts.service.ts
+++ b/src/modules/social/posts/posts.service.ts
@@ -1,25 +1,35 @@
 import { Post } from "@prisma/client"
 import { prisma } from "../../../utils"
 import { PostIncludes } from "./posts.controller"
-import {
-  CreateCommentSchema,
-  CreatePostBaseSchema,
-  CreatePostSchema
-} from "./posts.schema"
+import { CreateCommentSchema, CreatePostBaseSchema, CreatePostSchema } from "./posts.schema"
 
-export async function getPosts(sort: keyof Post = "created", sortOrder: "asc" | "desc" = "desc", limit = 100, offset = 0, includes: PostIncludes = {}) {
+export async function getPosts(
+  sort: keyof Post = "created",
+  sortOrder: "asc" | "desc" = "desc",
+  limit = 100,
+  offset = 0,
+  includes: PostIncludes = {},
+  tag: string | undefined
+) {
+  const whereTag = tag
+    ? {
+        tags: { has: tag }
+      }
+    : {}
+
   return await prisma.post.findMany({
     orderBy: {
       [sort]: sortOrder
     },
     take: limit,
     skip: offset,
+    where: { ...whereTag },
     include: {
       ...includes,
       _count: {
         select: {
           comments: true,
-          reactions: true,
+          reactions: true
         }
       }
     }
@@ -34,7 +44,7 @@ export async function getPost(id: number, includes: PostIncludes = {}) {
       _count: {
         select: {
           comments: true,
-          reactions: true,
+          reactions: true
         }
       }
     }
@@ -53,7 +63,7 @@ export const createPost = async (data: CreatePostSchema, includes: PostIncludes 
       _count: {
         select: {
           comments: true,
-          reactions: true,
+          reactions: true
         }
       }
     }
@@ -74,7 +84,7 @@ export const updatePost = async (id: number, data: CreatePostBaseSchema, include
       _count: {
         select: {
           comments: true,
-          reactions: true,
+          reactions: true
         }
       }
     }
@@ -118,27 +128,24 @@ export const createReaction = async (postId: number, symbol: string) => {
   return item
 }
 
-export const createComment = async (
-  postId: number,
-  owner: string,
-  comment: CreateCommentSchema
-) => await prisma.comment.create({
-  data: {
-    body: comment.body,
-    replyToId: comment.replyToId,
-    postId,
-    created: new Date(),
-    owner
-  },
-  select: {
-    id: true,
-    body: true,
-    created: true,
-    owner: true,
-    replyToId: true,
-    postId: true
-  }
-})
+export const createComment = async (postId: number, owner: string, comment: CreateCommentSchema) =>
+  await prisma.comment.create({
+    data: {
+      body: comment.body,
+      replyToId: comment.replyToId,
+      postId,
+      created: new Date(),
+      owner
+    },
+    select: {
+      id: true,
+      body: true,
+      created: true,
+      owner: true,
+      replyToId: true,
+      postId: true
+    }
+  })
 
 export const deleteComment = async (id: number) =>
   await prisma.comment.delete({
@@ -168,10 +175,18 @@ export const getPostsOfFollowedUsers = async (
   sortOrder: "asc" | "desc" = "desc",
   limit = 100,
   offset = 0,
-  includes: PostIncludes = {}
+  includes: PostIncludes = {},
+  tag: string | undefined
 ) => {
+  const whereTag = tag
+    ? {
+        tags: { has: tag }
+      }
+    : {}
+
   return await prisma.post.findMany({
     where: {
+      ...whereTag,
       author: {
         followers: {
           some: { id }
@@ -188,7 +203,7 @@ export const getPostsOfFollowedUsers = async (
       _count: {
         select: {
           comments: true,
-          reactions: true,
+          reactions: true
         }
       }
     }


### PR DESCRIPTION
- Adds `?_tag=x` flag to `GET /social/posts` and `GET /social/posts/following` with ability to filter by tag.

Each post can have multiple tags, but the `?_tag=` filter flag only accept filtering by a single tag.
For example: `GET /social/posts?_tag=chuck_norris` will return all posts that includes a `chuck_norris` tag in its tags array.

Closes #44 