### PR TITLE
Add ability to see bids by profile

### DIFF
--- a/src/modules/auction/listings/listings.schema.ts
+++ b/src/modules/auction/listings/listings.schema.ts
@@ -32,6 +32,11 @@ export const listingCore = {
 
 export const listingResponseSchema = z.object(listingCore)
 
+export const profileBidsResponseSchema = z.object({
+  ...bidCore,
+  listing: listingResponseSchema.omit({ bids: true, seller: true, _count: true }).optional()
+})
+
 const tagsAndMedia = {
   tags: z.union([
     z

--- a/src/modules/auction/profiles/profiles.route.ts
+++ b/src/modules/auction/profiles/profiles.route.ts
@@ -13,9 +13,10 @@ import {
   getProfileHandler,
   updateProfileMediaHandler,
   getProfileListingsHandler,
-  getProfileCreditsHandler
+  getProfileCreditsHandler,
+  getProfileBidsHandler
 } from "./profiles.controller"
-import { listingQuerySchema, listingResponseSchema } from "../listings/listings.schema"
+import { listingQuerySchema, listingResponseSchema, profileBidsResponseSchema } from "../listings/listings.schema"
 
 async function profilesRoutes(server: FastifyInstance) {
   server.get(
@@ -83,6 +84,23 @@ async function profilesRoutes(server: FastifyInstance) {
       }
     },
     getProfileListingsHandler
+  )
+
+  server.get(
+    "/:name/bids",
+    {
+      preHandler: [server.authenticate],
+      schema: {
+        tags: ["auction-profiles"],
+        security: [{ bearerAuth: [] }],
+        querystring: profilesQuerySchema,
+        params: profileNameSchema,
+        response: {
+          200: profileBidsResponseSchema.array()
+        }
+      }
+    },
+    getProfileBidsHandler
   )
 
   server.get(

--- a/src/modules/auction/profiles/profiles.service.ts
+++ b/src/modules/auction/profiles/profiles.service.ts
@@ -1,4 +1,4 @@
-import { AuctionListing, AuctionProfile } from "@prisma/client"
+import { AuctionBid, AuctionListing, AuctionProfile } from "@prisma/client"
 import { prisma } from "../../../utils"
 import { AuctionListingIncludes } from "../listings/listings.controller"
 import { AuctionProfileIncludes } from "./profiles.controller"
@@ -82,6 +82,27 @@ export async function getProfileCredits(name: string) {
     where: { name },
     select: {
       credits: true
+    }
+  })
+}
+
+export async function getProfileBids(
+  name: string,
+  sort: keyof AuctionBid = "created",
+  sortOrder: "asc" | "desc" = "desc",
+  limit = 100,
+  offset = 0,
+  includes: { listing?: boolean } = {}
+) {
+  return await prisma.auctionBid.findMany({
+    where: { bidderName: name },
+    orderBy: {
+      [sort]: sortOrder
+    },
+    take: limit,
+    skip: offset,
+    include: {
+      ...includes
     }
   })
 }


### PR DESCRIPTION
- Adds `GET /auction/profiles/:name/bids` endpoint that returns all bids made by profile. Also accepts `_listings` flag to return the listing for each bid.

Closes #39 