### PR TITLE
Make sure listing exists when transferring credits

### DIFF
--- a/src/modules/auction/listings/listing.utils.ts
+++ b/src/modules/auction/listings/listing.utils.ts
@@ -33,7 +33,7 @@ export async function scheduleCreditsTransfer(listingId: string, endsAt: Date): 
     // Get listing
     const listing = (await getListing(listingId, { bids: true })) as ListingWithBids
 
-    if (listing.bids.length > 0) {
+    if (listing?.bids?.length > 0) {
       // Get highest bid of listing
       const [winner, ...losers] = listing.bids.sort((a, b) => b.amount - a.amount)
 

--- a/src/modules/auction/listings/listing.utils.ts
+++ b/src/modules/auction/listings/listing.utils.ts
@@ -33,7 +33,7 @@ export async function scheduleCreditsTransfer(listingId: string, endsAt: Date): 
     // Get listing
     const listing = (await getListing(listingId, { bids: true })) as ListingWithBids
 
-    if (listing?.bids?.length > 0) {
+    if (listing && listing.bids.length > 0) {
       // Get highest bid of listing
       const [winner, ...losers] = listing.bids.sort((a, b) => b.amount - a.amount)
 


### PR DESCRIPTION
Going through logs I noticed this was throwing errors sometimes. Seeing as listings can be deleted by its creator, it also makes sense to make sure it exists before we attempt to transfer credits.