### PR TITLE
Add _active flag to listings

### DIFF
--- a/src/modules/auction/listings/listings.controller.ts
+++ b/src/modules/auction/listings/listings.controller.ts
@@ -31,11 +31,12 @@ export async function getListingsHandler(
       _seller?: boolean
       _bids?: boolean
       _tag?: string
+      _active?: boolean
     }
   }>,
   reply: FastifyReply
 ) {
-  const { sort, sortOrder, limit, offset, _bids, _seller, _tag } = request.query
+  const { sort, sortOrder, limit, offset, _bids, _seller, _tag, _active } = request.query
 
   if (limit && limit > 100) {
     throw new BadRequest("Limit cannot be greater than 100")
@@ -46,7 +47,7 @@ export async function getListingsHandler(
     seller: Boolean(_seller)
   }
 
-  const listings = await getListings(sort, sortOrder, limit, offset, includes, _tag)
+  const listings = await getListings(sort, sortOrder, limit, offset, includes, _tag, _active)
   reply.code(200).send(listings)
 }
 

--- a/src/modules/auction/listings/listings.schema.ts
+++ b/src/modules/auction/listings/listings.schema.ts
@@ -164,6 +164,7 @@ export const listingQuerySchema = z.object({
       invalid_type_error: "Tag must be a string"
     })
     .optional(),
+  _active: z.preprocess(val => String(val).toLowerCase() === "true", z.boolean()).optional(),
   ...queryFlagsCore
 })
 

--- a/src/modules/auction/listings/listings.service.ts
+++ b/src/modules/auction/listings/listings.service.ts
@@ -10,13 +10,11 @@ export async function getListings(
   limit = 100,
   offset = 0,
   includes: AuctionListingIncludes = {},
-  tag: string | undefined
+  tag: string | undefined,
+  active: boolean | undefined
 ) {
-  const whereTag = tag
-    ? {
-        tags: { has: tag }
-      }
-    : {}
+  const whereTag = tag ? { tags: { has: tag } } : {}
+  const whereActive = active ? { endsAt: { gte: new Date() } } : {}
 
   return await prisma.auctionListing.findMany({
     include: {
@@ -27,7 +25,10 @@ export async function getListings(
         }
       }
     },
-    where: { ...whereTag },
+    where: {
+      ...whereTag,
+      ...whereActive
+    },
     orderBy: {
       [sort]: sortOrder
     },

--- a/src/modules/auction/profiles/profiles.controller.ts
+++ b/src/modules/auction/profiles/profiles.controller.ts
@@ -89,12 +89,14 @@ export async function getProfileListingsHandler(
       sortOrder?: "asc" | "desc"
       _seller?: boolean
       _bids?: boolean
+      _tag?: string
+      _active?: boolean
     }
   }>,
   reply: FastifyReply
 ) {
   const { name } = request.params
-  const { sort, sortOrder, limit, offset, _seller, _bids } = request.query
+  const { sort, sortOrder, limit, offset, _seller, _bids, _tag, _active } = request.query
 
   if (limit && limit > 100) {
     throw new BadRequest("Limit cannot be greater than 100")
@@ -111,7 +113,7 @@ export async function getProfileListingsHandler(
     seller: Boolean(_seller)
   }
 
-  const listings = await getProfileListings(name, sort, sortOrder, limit, offset, includes)
+  const listings = await getProfileListings(name, sort, sortOrder, limit, offset, includes, _tag, _active)
   reply.code(200).send(listings)
 }
 

--- a/src/modules/auction/profiles/profiles.service.ts
+++ b/src/modules/auction/profiles/profiles.service.ts
@@ -57,10 +57,19 @@ export async function getProfileListings(
   sortOrder: "asc" | "desc" = "desc",
   limit = 100,
   offset = 0,
-  includes: AuctionListingIncludes = {}
+  includes: AuctionListingIncludes = {},
+  tag: string | undefined,
+  active: boolean | undefined
 ) {
+  const whereTag = tag ? { tags: { has: tag } } : {}
+  const whereActive = active ? { endsAt: { gte: new Date() } } : {}
+
   return await prisma.auctionListing.findMany({
-    where: { sellerName: name },
+    where: {
+      sellerName: name,
+      ...whereTag,
+      ...whereActive
+    },
     orderBy: {
       [sort]: sortOrder
     },


### PR DESCRIPTION
- Adds `_active` flag to `GET /auction/listings` to return only active listings.
- Adds `_active` flag to `GET /auction/profile/<name>/listings` to return only active listings.
- Adds `_tag` flag to `GET /auction/profile/<name>/listings`  to return all listings from profile that include a certain tag in its tags array.

The `_active` flag was mentioned in #64.