### PR TITLE
Add comment author to posts by profile

### DIFF
--- a/src/modules/social/profiles/profiles.service.ts
+++ b/src/modules/social/profiles/profiles.service.ts
@@ -129,6 +129,8 @@ export const getProfilePosts = async (
   offset = 0,
   includes: PostIncludes = {}
 ) => {
+  const withCommentAuthor = includes.comments ? { comments: { include: { author: true } } } : {}
+
   return await prisma.post.findMany({
     where: { owner: name },
     orderBy: {
@@ -138,6 +140,7 @@ export const getProfilePosts = async (
     skip: offset,
     include: {
       ...includes,
+      ...withCommentAuthor,
       _count: {
         select: {
           comments: true,


### PR DESCRIPTION
We added the author object to comments in #52 but are not returning this when getting posts from on a certain profile. This PR fixes this. The code already exists from that PR, but was not being returned with this endpoint.

Closes #72 