### PR TITLE
Tags max length

### DIFF
--- a/src/modules/auction/listings/listings.schema.ts
+++ b/src/modules/auction/listings/listings.schema.ts
@@ -43,6 +43,7 @@ const tagsAndMedia = {
       .string({
         invalid_type_error: "Tags must be an array of strings"
       })
+      .length(24, "Tags cannot be greater than 24 characters")
       .array()
       .max(8, "You cannot have more than 8 tags"),
     z.undefined()

--- a/src/modules/social/posts/posts.schema.ts
+++ b/src/modules/social/posts/posts.schema.ts
@@ -6,14 +6,16 @@ const tagsAndMedia = {
       .string({
         invalid_type_error: "Tags must be an array of strings"
       })
-      .array(),
+      .length(24, "Tags cannot be greater than 24 characters")
+      .array()
+      .max(8, "You cannot have more than 8 tags"),
     z.undefined()
   ]),
   media: z
     .string({
-      invalid_type_error: "Media must be a string"
+      invalid_type_error: "Image must be a string"
     })
-    .url("Must be valid URL")
+    .url("Image must be valid URL")
     .nullish()
     .or(z.literal(""))
 }


### PR DESCRIPTION
- Adds a max of 24 characters per tag to Posts and Listings.
- Adds limit of 8 tags to Posts. This already exists for Listings.
- Refine media/image error message for consistency.

Closes #60 