### PR TITLE
Use z.max instead of z.length

### DIFF
--- a/src/modules/auction/listings/listings.schema.ts
+++ b/src/modules/auction/listings/listings.schema.ts
@@ -43,7 +43,7 @@ const tagsAndMedia = {
       .string({
         invalid_type_error: "Tags must be an array of strings"
       })
-      .length(24, "Tags cannot be greater than 24 characters")
+      .max(24, "Tags cannot be greater than 24 characters")
       .array()
       .max(8, "You cannot have more than 8 tags"),
     z.undefined()

--- a/src/modules/social/posts/posts.schema.ts
+++ b/src/modules/social/posts/posts.schema.ts
@@ -6,7 +6,7 @@ const tagsAndMedia = {
       .string({
         invalid_type_error: "Tags must be an array of strings"
       })
-      .length(24, "Tags cannot be greater than 24 characters")
+      .max(24, "Tags cannot be greater than 24 characters")
       .array()
       .max(8, "You cannot have more than 8 tags"),
     z.undefined()


### PR DESCRIPTION
`.length()` requires the exact to be sent, and does not allow for under or over the set number. `.max()` will allow for all numbers up to the specified.