### PR TITLE
Return tags for profile route with listings flag

### DIFF
--- a/src/modules/auction/profiles/profiles.schema.ts
+++ b/src/modules/auction/profiles/profiles.schema.ts
@@ -74,6 +74,7 @@ export const displayProfileSchema = z.object({
       title: z.string(),
       description: z.string().nullish(),
       media: z.string().array().nullish(),
+      tags: z.string().array().nullish(),
       created: z.date(),
       updated: z.date(),
       endsAt: z.date()


### PR DESCRIPTION
- Adds missing `tags` property to listings returned via `/auction/profiles/<name>?_listings=true`

Closes #77 