### PR TITLE
Fixed listing endsAt

### DIFF
--- a/src/modules/auction/listings/listings.schema.ts
+++ b/src/modules/auction/listings/listings.schema.ts
@@ -82,7 +82,8 @@ export const createListingSchema = z.object({
       date => {
         const today = new Date()
         const oneYearFromToday = new Date(today.setFullYear(today.getFullYear() + 1))
-        if (date > oneYearFromToday || date < today) {
+        const now = new Date()
+        if (date > oneYearFromToday || date < now) {
           return false
         }
         return true


### PR DESCRIPTION
With the new check for `date < today` we're reusing the `today` variable which has been changed from actually being "today" to a year in the future at the `oneYearFromToday` variable where we use `setFullYear()`. Therefore the actual comparison would never return true. 