### PR TITLE
Removes token auth guard from venue get routes

### DIFF
--- a/src/modules/holidaze/venues/venues.route.ts
+++ b/src/modules/holidaze/venues/venues.route.ts
@@ -20,10 +20,8 @@ async function venuesRoutes(server: FastifyInstance) {
   server.get(
     "/",
     {
-      preHandler: [server.authenticate],
       schema: {
         tags: ["holidaze-venues"],
-        security: [{ bearerAuth: [] }],
         querystring: venuesQuerySchema,
         response: {
           200: displayVenueSchema.array()
@@ -36,10 +34,8 @@ async function venuesRoutes(server: FastifyInstance) {
   server.get(
     "/:id",
     {
-      preHandler: [server.authenticate],
       schema: {
         tags: ["holidaze-venues"],
-        security: [{ bearerAuth: [] }],
         params: venueIdSchema,
         querystring: queryFlagsSchema,
         response: {


### PR DESCRIPTION
Makes venue get routes public without auth requirements